### PR TITLE
Change .BaseUrl to .BaseURL

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,5 @@
 {{ partial "header.html" . }}
-{{ $baseurl := .Site.BaseUrl }}
+{{ $baseurl := .Site.BaseURL }}
 
 <div class="container">
   <div class="section">

--- a/layouts/partials/content.html
+++ b/layouts/partials/content.html
@@ -1,4 +1,4 @@
-{{ $baseurl := .Site.BaseUrl }}
+{{ $baseurl := .Site.BaseURL }}
 <div class="row">
 {{range $index, $page := .Paginator.Pages}}
   {{ if and (modBool $index 3) (ne 0 $index) }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -6,8 +6,8 @@
     </div>
   </footer>
   <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
-  <script src="{{.Site.BaseUrl}}/js/materialize.min.js"></script>
-  <script src="{{.Site.BaseUrl}}/js/init.js"></script>
+  <script src="{{.Site.BaseURL}}/js/materialize.min.js"></script>
+  <script src="{{.Site.BaseURL}}/js/init.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.5/highlight.min.js"></script>
   <script>hljs.initHighlightingOnLoad();</script>
   {{with  .Site.Params.googleAnalyticsUserID }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -4,14 +4,14 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no"/>
   <title>{{ .Title }}</title>
-  <link href="{{.Site.BaseUrl}}/css/materialize.min.css" type="text/css" rel="stylesheet" media="screen,projection"/>
-  <link href="{{.Site.BaseUrl}}/css/style.css" type="text/css" rel="stylesheet" media="screen,projection"/>
+  <link href="{{.Site.BaseURL}}/css/materialize.min.css" type="text/css" rel="stylesheet" media="screen,projection"/>
+  <link href="{{.Site.BaseURL}}/css/style.css" type="text/css" rel="stylesheet" media="screen,projection"/>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.5/styles/default.min.css">
   <style type="text/css">
   {{if .Site.Params.footerCover}}
-    footer.page-footer{background-image: url({{.Site.BaseUrl}}/{{.Site.Params.footerCover}});}
+    footer.page-footer{background-image: url({{.Site.BaseURL}}/{{.Site.Params.footerCover}});}
   {{else}}
-    footer.page-footer{background-image: url({{.Site.BaseUrl}}/images/default.png);}
+    footer.page-footer{background-image: url({{.Site.BaseURL}}/images/default.png);}
   {{end}}
   </style>
 </head>
@@ -19,32 +19,32 @@
   <div id="index-banner" class="parallax-container">
     <div class="section no-pad-bot">
       <div class="container">
-        <h1 class="header center teal-text text-lighten-2"><a href="{{.Site.BaseUrl}}">{{.Site.Title}}</a></h1>
+        <h1 class="header center teal-text text-lighten-2"><a href="{{.Site.BaseURL}}">{{.Site.Title}}</a></h1>
         <div class="row center">
           <h5 class="header col s12 light">{{.Site.Params.description}}</h5>
         </div>
         <div class="row center">
         {{if .Site.Params.github}}
-          <a href="https://github.com/{{ .Site.Params.github }}"><img src="{{.Site.BaseUrl}}/images/github2-dreamstale35.png"></a>
+          <a href="https://github.com/{{ .Site.Params.github }}"><img src="{{.Site.BaseURL}}/images/github2-dreamstale35.png"></a>
         {{end}}
         {{if .Site.Params.facebook}}
-          <a href="https://www.facebook.com/{{.Site.Params.facebook}}"><img src="{{.Site.BaseUrl}}/images/facebook-dreamstale25.png"></a>
+          <a href="https://www.facebook.com/{{.Site.Params.facebook}}"><img src="{{.Site.BaseURL}}/images/facebook-dreamstale25.png"></a>
         {{end}}
         {{if .Site.Params.twitter}}
-          <a href="https://twitter.com/{{.Site.Params.twitter}}"><img src="{{.Site.BaseUrl}}/images/twitter-dreamstale71.png"></a>
+          <a href="https://twitter.com/{{.Site.Params.twitter}}"><img src="{{.Site.BaseURL}}/images/twitter-dreamstale71.png"></a>
         {{end}}
         {{if .Site.Params.gplus}}
-          <a href="https://google.com/+{{.Site.Params.gplus}}"><img src="{{.Site.BaseUrl}}/images/gplus48x48.png"></a>
+          <a href="https://google.com/+{{.Site.Params.gplus}}"><img src="{{.Site.BaseURL}}/images/gplus48x48.png"></a>
         {{end}}
-          <a href="{{.Site.BaseUrl}}/index.xml"><img src="{{.Site.BaseUrl}}/images/feed-dreamstale27.png"></a>
+          <a href="{{.Site.BaseURL}}/index.xml"><img src="{{.Site.BaseURL}}/images/feed-dreamstale27.png"></a>
         </div>
       </div>
     </div>
     <div class="parallax">
     {{if .Site.Params.headerCover}}
-      <img src="{{.Site.BaseUrl}}/{{.Site.Params.headerCover}}">
+      <img src="{{.Site.BaseURL}}/{{.Site.Params.headerCover}}">
     {{else}}
-      <img src="{{.Site.BaseUrl}}/images/default.png">
+      <img src="{{.Site.BaseURL}}/images/default.png">
     {{end}}
     </div>
   </div>


### PR DESCRIPTION
Hugo adopted golint initialism formatting with:
https://github.com/spf13/hugo/pull/969

Hugo 0.14 throws an error saying compatibility with
the old capitalizations will be removed in 0.15

This change was produced with a quick and dirty
`grep -Irl BaseUrl | xargs ser -i -e "s/BaseUrl/BaseURL"`
