### PR TITLE
adding option for twitter summary content

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ copyright = "© 2015 Copyright Text"
 [params]
   description = "Your Site Description" # optional
   twitter = "Your Twitter Name" # optional
+  twitterSummary = true|false # optional
+  twitterTitle = "Title for twitter summary card" # optional
+  twitterDescription = "Desc for tiwtter summary card" # optional
+  twitterImage = "URL to image for twitter summary card" # option
   gitlab = "Your Gitlab Name" # optional
   github = "Your Github Name" # optional
   facebook = "Your facebook Name" # optional

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,6 +3,13 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no"/>
+  {{if .Site.Params.twitterSummary}}                                            
+      <meta name="twitter:card" content="summary" />                             
+      <meta name="twitter:site" content="@{{.Site.Params.twitter}}" />       
+      <meta name="twitter:title" content="{{.Site.Params.twitterTitle}}" />      
+      <meta name="twitter:description" content="{{.Site.Params.twitterDescription}}" />
+      <meta name="twitter:image" content="{{.Site.Params.twitterImage}}" />      
+  {{end}}
   <title>{{ .Title }}</title>
   <link href="{{.Site.BaseURL}}/css/materialize.min.css" type="text/css" rel="stylesheet" media="screen,projection"/>
   <link href="{{.Site.BaseURL}}/css/style.css" type="text/css" rel="stylesheet" media="screen,projection"/>


### PR DESCRIPTION
Added option to add [twtter summary card](https://dev.twitter.com/cards/types/summary) metadata to site
