### PR TITLE
fix bug: The hyperlink address should end with the character of '/'

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -7,7 +7,7 @@
 
     <div class="collection">
       {{ range $key, $value := .Data.Terms }}
-        <a href="{{$baseurl}}/{{ $data.Plural }}/{{ $key | urlize }}" class="collection-item">{{ if eq $data.Plural "tags"}}<i class="mdi-action-loyalty left"></i>{{else}}<i class="mdi-action-perm-media left"></i>{{end}}{{ $key }}<div class="secondary-content">{{ len $value }}</div></a>
+        <a href="{{$baseurl}}/{{ $data.Plural }}/{{ $key | urlize }}/" class="collection-item">{{ if eq $data.Plural "tags"}}<i class="mdi-action-loyalty left"></i>{{else}}<i class="mdi-action-perm-media left"></i>{{end}}{{ $key }}<div class="secondary-content">{{ len $value }}</div></a>
       {{ end }}
     </div>
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -18,8 +18,8 @@
 <body>
   <ul id="slide-out" class="side-nav">
     <li><a href="{{.Site.BaseURL}}"><i class="mdi-action-home left"></i>Home<i class="mdi-hardware-keyboard-arrow-right right"></i></a></li>
-    <li><a href="{{.Site.BaseURL}}/categories"><i class="mdi-action-perm-media left"></i>Categories<i class="mdi-hardware-keyboard-arrow-right right"></i></a></li>
-    <li><a href="{{.Site.BaseURL}}/tags"><i class="mdi-action-loyalty left"></i>Tags<i class="mdi-hardware-keyboard-arrow-right right"></i></a></li>
+    <li><a href="{{.Site.BaseURL}}/categories/"><i class="mdi-action-perm-media left"></i>Categories<i class="mdi-hardware-keyboard-arrow-right right"></i></a></li>
+    <li><a href="{{.Site.BaseURL}}/tags/"><i class="mdi-action-loyalty left"></i>Tags<i class="mdi-hardware-keyboard-arrow-right right"></i></a></li>
   </ul>
   <div id="index-banner" class="parallax-container">
   <a data-activates="slide-out" class="btn-floating button-collapse" style="top: 5px; left: 5px;"><i class="mdi-navigation-menu"></i></a>
@@ -31,9 +31,6 @@
           <h5 class="header col s12 light">{{.Site.Params.description}}</h5>
         </div>
         <div class="row center">
-        {{if .Site.Params.gitlab}}
-          <a href="https://gitlab.com/u/{{ .Site.Params.gitlab }}"><img src="{{.Site.BaseURL}}/images/gitlab.png"></a>
-        {{end}}
         {{if .Site.Params.github}}
           <a href="https://github.com/{{ .Site.Params.github }}"><img src="{{.Site.BaseURL}}/images/github2-dreamstale35.png"></a>
         {{end}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -31,6 +31,9 @@
           <h5 class="header col s12 light">{{.Site.Params.description}}</h5>
         </div>
         <div class="row center">
+        {{if .Site.Params.gitlab}}
+ -        <a href="https://gitlab.com/u/{{ .Site.Params.gitlab }}"><img src="{{.Site.BaseURL}}/images/gitlab.png"></a>
+ -      {{end}}
         {{if .Site.Params.github}}
           <a href="https://github.com/{{ .Site.Params.github }}"><img src="{{.Site.BaseURL}}/images/github2-dreamstale35.png"></a>
         {{end}}


### PR DESCRIPTION
As we all know the url of github is based on https protocol now, if the  hyperlink address is not end
with '/', the protocol of the url would become to http. This patch is to
fix this bug.
