### PR TITLE
Adds rel-me to social links

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -32,22 +32,22 @@
         </div>
         <div class="row center">
         {{if .Site.Params.gitlab}}
-          <a href="https://gitlab.com/u/{{ .Site.Params.gitlab }}"><img src="{{.Site.BaseURL}}/images/gitlab.png"></a>
+          <a href="https://gitlab.com/u/{{ .Site.Params.gitlab }}" rel="me"><img src="{{.Site.BaseURL}}/images/gitlab.png"></a>
         {{end}}
         {{if .Site.Params.github}}
-          <a href="https://github.com/{{ .Site.Params.github }}"><img src="{{.Site.BaseURL}}/images/github2-dreamstale35.png"></a>
+          <a href="https://github.com/{{ .Site.Params.github }}" rel="me"><img src="{{.Site.BaseURL}}/images/github2-dreamstale35.png"></a>
         {{end}}
         {{if .Site.Params.facebook}}
-          <a href="https://www.facebook.com/{{.Site.Params.facebook}}"><img src="{{.Site.BaseURL}}/images/facebook-dreamstale25.png"></a>
+          <a href="https://www.facebook.com/{{.Site.Params.facebook}}" rel="me"><img src="{{.Site.BaseURL}}/images/facebook-dreamstale25.png"></a>
         {{end}}
         {{if .Site.Params.twitter}}
-          <a href="https://twitter.com/{{.Site.Params.twitter}}"><img src="{{.Site.BaseURL}}/images/twitter-dreamstale71.png"></a>
+          <a href="https://twitter.com/{{.Site.Params.twitter}}" rel="me"><img src="{{.Site.BaseURL}}/images/twitter-dreamstale71.png"></a>
         {{end}}
         {{if .Site.Params.gplus}}
-          <a href="https://google.com/+{{.Site.Params.gplus}}"><img src="{{.Site.BaseURL}}/images/gplus48x48.png"></a>
+          <a href="https://google.com/+{{.Site.Params.gplus}}" rel="me"><img src="{{.Site.BaseURL}}/images/gplus48x48.png"></a>
         {{end}}
         {{if .Site.Params.linkedin}}
-          <a href="https://www.linkedin.com/in/{{.Site.Params.linkedin}}"><img src="{{.Site.BaseURL}}/images/linkedin-dreamstale45.png"></a>
+          <a href="https://www.linkedin.com/in/{{.Site.Params.linkedin}}" rel="me"><img src="{{.Site.BaseURL}}/images/linkedin-dreamstale45.png"></a>
         {{end}}
           <a href="{{.Site.BaseURL}}/index.xml"><img src="{{.Site.BaseURL}}/images/feed-dreamstale27.png"></a>
         </div>


### PR DESCRIPTION
[rel="me"](https://indieweb.org/rel-me) is a commonly used way to show that that two websites or social media accounts are the same, and is used for authentication and proving site ownership in a variety of ways.